### PR TITLE
Update conceptual-schemas.xml

### DIFF
--- a/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
+++ b/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
@@ -918,6 +918,16 @@
                         <cs:primitive>true</cs:primitive>
                      </cs:XsdType>
                   </cs:xsdTypes>
+               </cs:Construct>        
+               <cs:Construct>
+                  <cs:name>Nummer</cs:name>
+                  <cs:sentinel>false</cs:sentinel>
+                  <cs:xsdTypes>
+                     <cs:XsdType>
+                        <cs:name>xs:integer</cs:name>
+                        <cs:primitive>true</cs:primitive>
+                     </cs:XsdType>
+                  </cs:xsdTypes>
                </cs:Construct>
                <cs:Construct>
                   <cs:name>Organisatie</cs:name>


### PR DESCRIPTION
Added Nummer from BRO Common. Needed for GAR. 
Length of primitive datatypes is now specified on TV, not in the name of the type anymore.