### PR TITLE
Coördinatenpaar vervangen door Coordinatepaar, dus zonder diakriet.

### DIFF
--- a/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
+++ b/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
@@ -1041,7 +1041,7 @@
                   </cs:xsdTypes>
                </cs:Construct>
                <cs:Construct>
-                  <cs:name>Coördinatenpaar</cs:name>
+                  <cs:name>Coordinatenpaar</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:xsdTypes>
                      <cs:XsdType>


### PR DESCRIPTION
Gebruik van diakriet leidt tot een bug.
Bij mijn weten zijn zowel dit bestand als het aangeboden MODEL.XMI correct volgens UTF-8 gecodeerd.
Vermoeden is dus dat er een bug zit ergens in Imvertor.
Een bug fix is dus een optie.
Maar de MIM handleiding zegt dat voor namen van modelelementen de CamelCase namingconvention wordt gehanteerd.
Het gebruik van diakrieten is strijdig daarmee.
Dus is gekozen voor het verwijderen van het diakritische teken ö (o-umlaut) in Coördinatenpaar.