### PR TITLE
BHR terug opgenomen als registratie-object

### DIFF
--- a/src/main/resources/input/BRO/cfg/local/registration-objects.xml
+++ b/src/main/resources/input/BRO/cfg/local/registration-objects.xml
@@ -65,13 +65,11 @@
             <name lang="en">Seismic survey</name>
             <abbrev>SMS</abbrev>
         </registratieobject>
-        <!--
         <registratieobject>
             <name lang="nl">Booronderzoek</name>
             <name lang="en">Borehole research</name>
             <abbrev>BHR</abbrev>
         </registratieobject>
-        -->
         <registratieobject>
             <name lang="nl">Bodemkundig booronderzoek</name>
             <name lang="en">Borehole research-Pedology</name>


### PR DESCRIPTION
Het uitcommentarieren van BHR leverde fouten op bij aanleveren van BHR-GT, BHR-P en BHR-G.