### PR TITLE
Uitschakelen Mapping GML321 in conceptual schemas

### DIFF
--- a/src/main/resources/input/Geonovum/xsd/conceptual-schemas.xml
+++ b/src/main/resources/input/Geonovum/xsd/conceptual-schemas.xml
@@ -7,7 +7,7 @@
                       xsi:schemaLocation="http://www.imvertor.org/metamodels/conceptualschemas/model/v20181210
                       ../../../etc/xsd/ConceptualSchema/root/model/v20181210/ConceptualSchemas_Model_v1_0.xsd">
    <cs:mappings>
-      <cs:Mapping>
+      <!--cs:Mapping>
          <cs:name>GML321</cs:name>
          <cs:use>
             <cs-ref:MapRef xlink:href="#GML321"/>
@@ -15,7 +15,7 @@
             <cs-ref:MapRef xlink:href="#CITYGML"/>
             <cs-ref:MapRef xlink:href="#STUB"/>
          </cs:use>
-      </cs:Mapping>
+      </cs:Mapping-->
       <cs:Mapping>
          <cs:name>NEN3610_GML321</cs:name>
          <cs:use>


### PR DESCRIPTION
N.a.v. Imvertor foutmelding

Reference to ""Real"" in outside model is not identified, but should be, as duplicates occur using mapping ""NEN3610_GML321

lijkt er een dubbele mapping te zijn naar het construct Real in Mapping GML321 en NEN3610_GML321.
Mapping NEN3610_GML321 is uitgebreider dan Mapping GML321, vandaar uitschakelen Mapping GML321.

Verwachting is dat het uitschakelen van Mapping GML321 de foutmelding wordt voorkomen.