### PR TITLE
TV Naam in meervoud op entiteittype in UGM verplicht gemaakt.

### DIFF
--- a/src/main/resources/input/KING/cfg/tvsets/KINGUGM.xml
+++ b/src/main/resources/input/KING/cfg/tvsets/KINGUGM.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
  * Copyright (C) 2016 Dienst voor het kadaster en de openbare registers
- * 
+ *
  * This file is part of Imvertor.
  *
  * Imvertor is free software: you can redistribute it and/or modify
@@ -18,21 +18,21 @@
  * along with Imvertor.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <tagset type="config" xmlns:xi="http://www.w3.org/2001/XInclude">
-   
+
     <!-- KING refines grouping -->
     <xi:include href="KINGGrouping.xml"/>
 
-    <!-- 
+    <!--
         applications using this metamodel may reference cross-meta Tagged values taken from SIM
     -->
     <xi:include href="KINGUGM-cross-SIM.xml"/>
 
     <xi:include href="KINGBSM-cross-SIM-and-UGM.xml"/>
-    
+
     <name>KINGUGM</name>
-    
+
     <tagged-values>
-        
+
         <tv norm="compact" rules="NOC" id="CFG-TV-INDICATIEMATCHGEGEVEN">
             <name lang="nl">Indicatie matchgegeven</name>
             <derive>yes</derive>
@@ -48,7 +48,7 @@
                 <value default="yes">Nee</value>
             </declared-values>
         </tv>
-        
+
         <tv norm="space" rules="NOC" id="CFG-TV-INDICATIONAUTHENTIC">
             <name lang="nl">Indicatie authentiek</name>
             <derive>yes</derive>
@@ -59,7 +59,7 @@
                 <stereo minmax="0..1">stereotype-name-relatiesoort</stereo>
             </stereotypes>
          </tv>
-        
+
         <tv norm="compact" rules="NOC" id="CFG-TV-INDICATIONMATERIALHISTORY">
             <name lang="nl">Indicatie materiële historie</name>
             <desc lang="nl">Voorziening waarmee aangegeven kan worden of materiële historie van toepassing is op de constructie.</desc>
@@ -98,19 +98,19 @@
             <derive>yes</derive><!-- UGM mag op supplier terugvallen, maar SIM is niet een supplier voor deze config, dus expliciet de naam opnemen.-->
             <desc lang="nl">De indicatie of te bevragen is dat er twijfel is of is geweest aan de juistheid van de attribuutwaarde en dat een onderzoek wordt of is uitgevoerd naar de juistheid van de attribuutwaarde. </desc>
         </tv>
-        
+
         <tv norm="space" validate="" rules="" id="CFG-TV-VERKORTEALIAS">
             <name lang="nl">Verkorte alias</name>
             <name lang="en">Short alias</name>
             <derive>no</derive>
-            <desc lang="nl">Verkorte alias is een korte naam, die uiteindelijk gekoppeld is aan een namespace in XML schema. 
+            <desc lang="nl">Verkorte alias is een korte naam, die uiteindelijk gekoppeld is aan een namespace in XML schema.
                 In feite is het dus een technisch configuratie-element. Heeft alleen een toepassing binnen StUF schema's.</desc>
             <stereotypes>
                 <stereo minmax="1..1">stereotype-name-application-package</stereo>
                 <stereo minmax="0..1">stereotype-name-base-package</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-PATTERN">
             <name lang="nl">Patroon</name>
             <name lang="en">Pattern</name>
@@ -152,7 +152,7 @@
                 <value default="yes">Nee</value>
             </declared-values>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-MAXLENGTH">
             <name lang="nl">Lengte</name>
             <desc lang="nl">De maximale lengte die een attribuut kan hebben.</desc>
@@ -163,7 +163,7 @@
                 <stereo minmax="0..1">stereotype-name-simpletype</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-MINLENGTH">
             <name lang="nl">Minimum lengte</name>
             <desc lang="nl">De minimale lengte die een attribuut moet hebben.</desc>
@@ -174,7 +174,7 @@
                 <stereo minmax="0..1">stereotype-name-simpletype</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-MINVALUEINCLUSIVE">
             <name lang="nl">Minimum waarde (inclusief)</name>
             <desc lang="nl">De minimale waarde (inclusief) dat een attribuut moet hebben</desc>
@@ -185,7 +185,7 @@
                 <stereo minmax="0..1">stereotype-name-simpletype</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-MAXVALUEINCLUSIVE">
             <name lang="nl">Maximum waarde (inclusief)</name>
             <desc lang="nl">DDe maximale waarde (inclusief) dat een attribuut mag hebben.</desc>
@@ -196,7 +196,7 @@
                 <stereo minmax="0..1">stereotype-name-simpletype</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="note" id="CFG-TV-DESCRIPTION">
             <name lang="nl">Toelichting</name>
             <name lang="en">Description</name>
@@ -214,13 +214,13 @@
                 <stereo minmax="0..1">stereotype-name-simpletype</stereo>
                 <stereo minmax="0..1">stereotype-name-complextype</stereo>
                 <stereo minmax="0..1">stereotype-name-union</stereo>
-                
+
                 <stereo minmax="0..1">stereotype-name-data-element</stereo>
                 <stereo minmax="0..1">stereotype-name-union-element</stereo>
                 <stereo minmax="0..1">stereotype-name-enum</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space"  id="CFG-TV-SUBSETLABEL">
             <name lang="nl">Restriction identifier</name>
             <name lang="en">Restriction identifier</name>
@@ -245,7 +245,7 @@
                 <stereo minmax="0..1">stereotype-name-enum</stereo>
             </stereotypes>
         </tv>
-       
+
         <!-- TODO PATCH, must be removed! -->
         <tv norm="compact" rules="NOC" id="CFG-TV-INDICATIEKERNGEGEVEN">
             <name lang="nl">Indicatie kerngegeven</name>
@@ -262,17 +262,17 @@
                 <value default="yes">Nee</value>
             </declared-values>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-NAMEPLURAL">
             <name lang="nl">Naam in meervoud</name>
             <desc lang="nl">
-                Voorziening om een entiteit een meervoudsnaam te kunnen geven. Deze wordt gebruikt als propertynaam van een entiteit in het yaml bestand. 
+                Voorziening om een entiteit een meervoudsnaam te kunnen geven. Deze wordt gebruikt als propertynaam van een entiteit in het yaml bestand.
             </desc>
             <stereotypes>
-                <stereo minmax="0..1">stereotype-name-objecttype</stereo>
+                <stereo minmax="1..1">stereotype-name-objecttype</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-TARGETROLEPLURAL">
             <name lang="nl">Target role in meervoud</name>
             <desc lang="nl">
@@ -282,19 +282,19 @@
                 <stereo minmax="1..1">stereotype-name-relatiesoort</stereo>
             </stereotypes>
         </tv>
-        
+
         <tv id="CFG-TV-GROUPNAME">
             <name lang="nl">Groepsnaam</name>
             <name lang="en">Groupname</name>
             <desc lang="nl">
-                Voorziening om een groep aangepaste naam te kunnen geven. 
+                Voorziening om een groep aangepaste naam te kunnen geven.
             </desc>
             <derive>no</derive>
             <stereotypes>
                 <stereo minmax="0..1">stereotype-name-composite</stereo>
             </stereotypes>
         </tv>
-  
+
         <!-- specify that UGM uses markdown notes fields -->
         <tv id="CFG-TV-DEFINITION" norm="note">
             <!-- none additional -->
@@ -302,11 +302,11 @@
         <tv id="CFG-TV-DESCRIPTION" norm="note">
             <!-- none additional -->
         </tv>
-        
+
         <tv norm="space" id="CFG-TV-ENDPOINTAVAILABLE">
             <name lang="nl">Endpoint beschikbaar</name>
             <desc lang="nl">
-                Voorziening waarmee kan worden aangegeven dat er voor een entiteit al dan niet een resource endpoint beschikbaar is. 
+                Voorziening waarmee kan worden aangegeven dat er voor een entiteit al dan niet een resource endpoint beschikbaar is.
             </desc>
             <derive>no</derive>
             <stereotypes>
@@ -317,6 +317,6 @@
                 <value>Nee</value>
             </declared-values>
         </tv>
-        
+
     </tagged-values>
 </tagset>


### PR DESCRIPTION
Ik heb alleen de kardinaliteit van deze TV aangepast. Het zal een editor dingetje zijn dat hier allerlei spaties zijn weggehaald. (Ik gebruik Atom). Ik ga er van uit dat het verwijderen van de spaties geen impact heeft iop de werking. 