### PR TITLE
1/ Initiele commit MIM XML Schema "fase 2" en 2/ metagegevens op informatiemodel niveau (MIMVersie, MIMTaal, informatiedomein etc) worden nu correct gegenereerd

### DIFF
--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimExt_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimExt_v1.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:mim-ext="http://www.geostandaarden.nl/mim-ext/informatiemodel/v1" 
+  targetNamespace="http://www.geostandaarden.nl/mim-ext/informatiemodel/v1" 
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified" 
+  version="1">
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/uri">http://www.geostandaarden.nl/mim-ext/informatiemodel/v1</xs:appinfo>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/version">1</xs:appinfo>
+  </xs:annotation>
+  
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+
+  <xs:element name="ConstructieRef" type="mim-ext:RefType"/>
+
+  <xs:element name="kenmerken">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="kenmerk" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="naam" type="xs:string"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="constructies">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="mim-ext:ConstructieRef" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="Constructie">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="constructietype" type="xs:string"/>
+        <xs:any namespace="http://www.geostandaarden.nl/mim-ext/informatiemodel/v1" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID" use="required"/>
+    </xs:complexType>
+  </xs:element>
+    
+  <xs:complexType name="RefType" abstract="true">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xlink:href" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimRef_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimRef_v1.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:mim-ref="http://www.geostandaarden.nl/mim-ref/informatiemodel/v1"   
+  targetNamespace="http://www.geostandaarden.nl/mim-ref/informatiemodel/v1" 
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified" 
+  version="1">
+  
+  <xs:annotation>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/uri">http://www.geostandaarden.nl/mim-ref/informatiemodel/v1</xs:appinfo>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/version">1</xs:appinfo>
+  </xs:annotation>
+  
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  
+  <xs:element name="ObjecttypeRef" type="mim-ref:RefType"/>
+  <xs:element name="GegevensgroeptypeRef" type="mim-ref:RefType"/>
+  <xs:element name="AttribuutsoortRef" type="mim-ref:RefType"/>
+  <xs:element name="GegevensgroepRef" type="mim-ref:RefType"/>
+  <xs:element name="DatatypeRef" type="mim-ref:RefType"/>
+  <!--
+  <xs:element name="GestructureerdDatatypeRef" type="mim-ref:RefType"/>
+  <xs:element name="PrimitiefDatatypeRef" type="mim-ref:RefType"/>
+  <xs:element name="EnumeratieRef" type="mim-ref:RefType"/>
+  <xs:element name="CodelijstRef" type="mim-ref:RefType"/>
+  <xs:element name="ReferentielijstRef" type="mim-ref:RefType"/>
+  -->
+  <xs:element name="RelatieklasseRef" type="mim-ref:RefType"/>
+  <xs:element name="KeuzeRef" type="mim-ref:RefType"/>
+  <xs:element name="InterfaceRef" type="mim-ref:RefType"/>
+  
+  <xs:complexType name="RefType" abstract="true">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xlink:href" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+</xs:schema>

--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
@@ -1,0 +1,1665 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:mim="http://www.geostandaarden.nl/mim/informatiemodel/v1" 
+  xmlns:mim-ref="http://www.geostandaarden.nl/mim-ref/informatiemodel/v1" 
+  xmlns:mim-ext="http://www.geostandaarden.nl/mim-ext/informatiemodel/v1" 
+  targetNamespace="http://www.geostandaarden.nl/mim/informatiemodel/v1" 
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified" 
+  version="1">
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/uri">http://www.geostandaarden.nl/mim/informatiemodel/v1</xs:appinfo>
+    <xs:appinfo source="http://www.imvertor.org/schema-info/version">1</xs:appinfo>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.geostandaarden.nl/mim-ref/informatiemodel/v1" schemaLocation="MIMFORMAT_MimRef_v1.xsd"/>
+  <xs:import namespace="http://www.geostandaarden.nl/mim-ext/informatiemodel/v1" schemaLocation="MIMFORMAT_MimExt_v1.xsd"/>
+
+  <!-- Informatiemodel: -->
+  <xs:element name="Informatiemodel" type="mim:Informatiemodel">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De groepering van alle modelelementen waaruit het informatiemodel is opgebouwd. Het informatiemodel als geheel.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Informatiemodel">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de view package. Deze is, indien mogelijk, analoog aan de naamgeving in het externe schema waar de view over gaat, eventueel met een prefix.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de package.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan het package ontleend is. Bij een view is de herkomst nooit de eigen organsiatie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="informatiedomein" type="xs:string"/>
+      <xs:element name="informatiemodeltype" type="xs:string"/>
+      <xs:element name="relatiemodelleringstype" type="mim:relatiemodelleringstype"/>
+      <xs:element name="MIMVersie" type="xs:string"/>
+      <xs:element name="MIMExtensie" type="xs:string" minOccurs="0"/>
+      <xs:element name="MIMTaal" type="xs:string" minOccurs="0"/>
+      <xs:element name="packages" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:Domein" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:View" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Extern" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="components" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:Objecttype" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Gegevensgroeptype" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Gegevensgroep" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:GestructureerdDatatype" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:PrimitiefDatatype" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Enumeratie" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Codelijst" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Referentielijst" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Keuze" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:ExterneKoppeling" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Interface" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="mim-ext:Constructie" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+
+  <!-- DomeinOfView: -->
+  <xs:element name="DomeinOfView" type="mim:DomeinOfView" abstract="true"/>
+  <xs:complexType name="DomeinOfView" abstract="true">
+    <xs:sequence>
+      <xs:element name="datatypen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:DatatypeRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="objecttypen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:ObjecttypeRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="gegevensgroeptypen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:GegevensgroeptypeRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="keuzen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:KeuzeRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:constructies" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Domein: -->
+  <xs:element name="Domein" type="mim:Domein">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een groepering van constructies die een semantisch samenhangend gedeelte van een informatiemodel beschrijven.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Domein">
+    <xs:complexContent>
+      <xs:extension base="mim:DomeinOfView">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de domein package. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- View: -->
+  <xs:element name="View" type="mim:View">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een groepering van objecttypen die gespecificeerd zijn in een extern informatiemodel en vanuit het perspectief van het eigen informatiemodel inzicht geeft welke gegevens van deze objecttypen relevant zijn binnen het eigen informatiemodel.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="View">
+    <xs:complexContent>
+      <xs:extension base="mim:DomeinOfView">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de view package. Deze is, indien mogelijk, analoog aan de naamgeving in het externe schema waar de view over gaat, eventueel met een prefix.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="locatie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verwijzing naar de locatie van de bijbehorende schema’s waar de view over gaat.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de package.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan het package ontleend is. Bij een view is de herkomst nooit de eigen organsiatie.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Extern: -->
+  <xs:element name="Extern" type="mim:Extern">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een groepering van constructies die een externe instantie beheert en beschikbaar stelt aan een informatiemodel en die in het informatiemodel ongewijzigd gebruikt worden.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Extern">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de externe package zoals gespecificeerd door de externe instantie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="locatie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verwijzing naar de locatie van de bijbehorende schema’s.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de package.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan het package ontleend is. Bij een view is de herkomst nooit de eigen organsiatie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="interfaces" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:InterfaceRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Objecttype: -->
+  <xs:element name="Objecttype" type="mim:Objecttype">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een ding, een tastbaar iets, in de werkelijkheid, zoals daarnaar gekeken wordt vanuit een bepaald domein.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Objecttype">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van het objecttype.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie in wiens catalogus het objecttype is gespecificeerd (oftewel de registratie waar het objecttype deel van uitmaakt). Deze specificatie is toegevoegd omdat het wel duidelijk moet zijn in welke (basis)registratie of informatiemodel het objecttype voorkomt (indien van toepassing). </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van het objecttype zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie of informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een registratie is de definitie hieruit overgenomen.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het objecttype is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="uniekeAanduiding" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een (basis)registratie of informatiemodel betreft dit de wijze waarop daarin voorkomende objecten (van dit type) uniek in de registratie worden aangeduid. Afgeleid gegeven op basis van combinatie van attribuutsoorten en relatiesoorten met is ID = True</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="populatie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een (basis)registratie betreft dit de beschrijving van de exemplaren van het gedefinieerde objecttype die in de desbetreffende (basis)registratie voorhanden zijn.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kwaliteit" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een registratie betreft dit de waarborgen voor de juistheid van de in de registratie opgenomen objecten van het desbetreffende type.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een (basis)registratie of informatiemodel betreft dit de daarin opgenomen toelichting.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieAbstractObject" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie dat er geen instanties (objecten) voor het betreffende objecttype mogen voorkomen.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="supertype" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:GeneralisatieObjecttypes"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim:attribuutsoorten" minOccurs="0"/>
+      <xs:element ref="mim:gegevensgroepen" minOccurs="0"/>
+      <xs:element name="relatiesoorten" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:Relatiesoort" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="externeKoppelingen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:ExterneKoppeling" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="keuzen" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:KeuzeRef" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim:constraints" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+
+  <!-- Gegevensgroeptype: -->
+  <xs:element name="Gegevensgroeptype" type="mim:Gegevensgroeptype">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een groep van met elkaar samenhangende attribuutsoorten. Een gegevensgroeptype is altijd een type van een gegevensgroep.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Gegevensgroeptype">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de type gegevensgroep.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de attribuutsoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de attribuutsoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string"/>
+      <xs:element ref="mim:attribuutsoorten" minOccurs="0"/>
+      <xs:element ref="mim:gegevensgroepen" minOccurs="0"/>
+      <xs:element ref="mim:constraints" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+
+  <!-- Attribuutsoort: -->
+  <xs:element name="Attribuutsoort" type="mim:Attribuutsoort">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van gelijksoortige gegevens die voor een objecttype van toepassing is.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Attribuutsoort">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de attribuutsoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de attribuutsoort ontleend is dan wel de eigen organisatie indien het door de eigen organisatie toegevoegd is.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de attribuutsoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de attribuutsoort is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="type">
+        <xs:complexType>
+          <xs:choice>
+            <xs:element ref="mim-ref:DatatypeRef"/>
+            <xs:element ref="mim-ref:KeuzeRef"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="lengte" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De aanduiding van de lengte van een gegeven. Getallen kunnen altijd positief of negatief zijn.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="patroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verzameling van waarden die gegevens van deze attribuutsoort kunnen hebben (bereik) danwel moeten voldoen aan een specifiek patroon.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="formeelPatroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Zoals patroon , formeel vastgelegd (met een reguliere expressie)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de attribuutsoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de attribuutwaarde.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de attribuutsoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de attribuutwaarde (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kardinaliteit" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Deze indicatie geeft aan hoeveel keer waarden van deze attribuutsoort kunnen voorkomen bij een object van het betreffende objecttype.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="authentiek" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of het een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de attribuutsoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieAfleidbaar" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat gegeven afleidbaar is uit andere attribuut- en/of relatiesoorten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieClassificerend" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie dat een attribuutsoort het objecttype waar het bijhoort classificeert in (sub)typen.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat attribuutsoort geen waarde met betekenis kan bevatten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="identificerend" type="mim:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat attribuutsoort onderdeel uitmaakt van de unieke aanduiding van een object.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Gegevensgroep: -->
+  <xs:element name="Gegevensgroep" type="mim:Gegevensgroep">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een typering van een groep van gelijksoortige gegevens die voor een objecttype van toepassing is.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Gegevensgroep">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de compositie relatie. Deze moet ingevuld zijn indien er twee of meer soorten compositie relaties zijn tussen hetzelfde objecttype en hetzelfde gegevensgroeptype.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de type gegevensgroep.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de type gegevensgroep.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de type gegevensgroep ontleend is dan wel de eigen organisatie indien het door de eigen organisatie toegevoegd is.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de type gegevensgroep is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="type">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:GegevensgroeptypeRef"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de type gegevensgroep te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de attribuutwaarde.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de type gegevensgroep te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de attribuutwaarde (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kardinaliteit" type="xs:string"/>
+      <xs:element name="authentiek" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of het een authentiek gegeven betreft.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Relatiesoort: -->
+  <xs:element name="Relatiesoort" type="mim:Relatiesoort">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van het structurele verband tussen een object van een objecttype en een (ander) object van een ander (of hetzelfde) objecttype.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Relatiesoort">
+    <xs:choice>
+      <xs:element name="RelatiesoortLeidend">
+        <!-- Relatiesoort leidend (alternatief 1); relatiemodelleringstype == "Relatiesoort leidend" -->
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="naam" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="alias" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="uniDirectioneel" type="xs:string"/>
+            <xs:element name="doel">
+              <xs:complexType>
+                <xs:choice>
+                  <xs:choice>
+                    <xs:element ref="mim-ref:ObjecttypeRef"/>
+                    <xs:element ref="mim-ref:KeuzeRef"/>
+                  </xs:choice>
+                  <xs:element ref="mim:Relatierol"/>
+                </xs:choice>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="aggregatieType" type="mim:typeAggregatie">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Standaard betreft het geen aggregatie (None). Het type aggregatie mag ‘composite’ zijn. Dit wordt gedaan als er een afhankelijkheid is dat de target niet kan bestaan zonder de source c.q. de target vervalt als de source vervalt.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="kardinaliteit" type="xs:string"/>
+            <xs:element name="herkomst" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatiesoort ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="definitie" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="toelichting" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatiesoort.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="herkomstDefinitie" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="datumOpname" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatiesoort is opgenomen in het informatiemodel.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatiesoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="authentiek" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatiesoort is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="indicatieAfleidbaar" type="mim:boolean"/>
+            <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatiesoort geen waarde met betekenis kan bevatten.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
+            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+          </xs:sequence>  
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="RelatierolLeidend">
+        <!-- Relatierol is leidend (alternatief 2); relatiemodelleringstype == "Relatierol leidend" -->    
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="naam" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="alias" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="definitie" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
+            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+          </xs:sequence>  
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Relatierol: -->
+  <xs:element name="Relatierol" type="mim:Relatierol" abstract="true">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De benaming van de manier waarop een object deelneemt aan een relatie met een ander object.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Relatierol" abstract="true">
+    <xs:choice>
+      <xs:element name="RelatiesoortLeidend">
+        <!-- Relatiesoort leidend (alternatief 1); relatiemodelleringstype == "Relatiesoort leidend" -->
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="naam" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="alias" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="definitie" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+          </xs:sequence>  
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="RelatierolLeidend">
+        <!-- Relatierol is leidend (alternatief 2); relatiemodelleringstype == "Relatierol leidend" -->    
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="naam" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="alias" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="herkomst" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatiesoort ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="definitie" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="herkomstDefinitie" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="datumOpname" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatiesoort is opgenomen in het informatiemodel.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="kardinaliteit" type="xs:string"/>
+            <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatiesoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="authentiek" type="xs:string">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatiesoort is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatiesoort geen waarde met betekenis kan bevatten.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="toelichting" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatiesoort.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+  
+  <!-- RelatierolBron: -->
+  <xs:element name="RelatierolBron" type="mim:RelatierolBron">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De relatierol die de rol beschrijft van de bron van de relatie.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="RelatierolBron">
+    <xs:complexContent>
+      <xs:extension base="mim:Relatierol"/>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <!-- RelatierolDoel: -->
+  <xs:element name="RelatierolDoel" type="mim:RelatierolDoel">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De relatierol die de rol beschrijft van het doel van de relatie.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="RelatierolDoel">
+    <xs:complexContent>
+      <xs:extension base="mim:Relatierol">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatierol.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="alias" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatierol ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Beschrijving van de betekenis van de relatierol.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomstDefintie" type="xs:string"/>
+          <xs:element name="datumOpname" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatierol is opgenomen in het informatiemodel.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="kardinaliteit" type="xs:string"/>
+          <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatierol te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesrol te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="authentiek" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatierol is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatierol geen waarde met betekenis kan bevatten.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="toelichting" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatierol.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Datatype: -->
+  <xs:element name="Datatype" type="mim:Datatype" abstract="true">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een beschrijving van de structuur waaraan een waarde, oftewel de data zelf, aan moet voldoen.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Datatype" abstract="true">
+    <xs:sequence>
+      <xs:element name="supertype" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim:GeneralisatieDatatypes"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+
+  <!-- Primitief Datatype -->
+  <xs:element name="PrimitiefDatatype" type="mim:PrimitiefDatatype">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een in het eigen model gedefinieerd datatype die gebaseerd is op een PrimitiveType, met een eigen naam en definitie.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="PrimitiefDatatype">
+    <xs:complexContent>
+      <xs:extension base="mim:Datatype">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de complex datatype zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string" minOccurs="0"/>
+          <xs:element name="lengte" type="xs:string" minOccurs="0"/>
+          <xs:element name="patroon" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De samenstelling van het complex datatype bestaande uit twee of meer data elementenmoet voldoen aan een specifiek patroon.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="formeelPatroon" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Zoals patroon , formeel vastgelegd (met een reguliere expressie)</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de complex datatype ontleend is dan wel de eigen organisatie indien het door de eigen organisatie toegevoegd is.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="datumOpname" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het complex datatype is opgenomen in het informatiemodel.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Gestructureerd Datatype -->
+  <xs:element name="GestructureerdDatatype" type="mim:GestructureerdDatatype">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Specifiek benoemd datatype dat de structuur van een gegeven beschrijft, samengesteld uit minimaal twee elementen die in samenhang betekenisvol zijn.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="GestructureerdDatatype">
+    <xs:complexContent>
+      <xs:extension base="mim:Datatype">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de complex datatype zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de complex datatype ontleend is dan wel de eigen organisatie indien het door de eigen organisatie toegevoegd is.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de complex datatype zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="patroon" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De samenstelling van het complex datatype bestaande uit twee of meer data elementenmoet voldoen aan een specifiek patroon.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="formeelPatroon" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Zoals patroon , formeel vastgelegd (met een reguliere expressie)</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="datumOpname" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het complex datatype is opgenomen in het informatiemodel.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="dataElementen" minOccurs="0">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element ref="mim:DataElement" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Data Element -->
+  <xs:element name="DataElement" type="mim:DataElement">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een onderdeel/element van een Gestructureerd datatype die als type een datatype heeft. </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="DataElement">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van het data element zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van het data element zoals gespecificeerd in de catalogus van de desbetreffende (basis)registratie. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="type">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:DatatypeRef"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="lengte" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Het exact aantal tekens dat de waarde van een data element moet bevatten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="patroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verzameling van waarden die gegevens van deze data element kunnen hebben (bereik) dan wel moeten voldoen aan een specifiek patroon.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="formeelPatroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Zoals patroon , formeel vastgelegd (met een reguliere expressie)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kardinaliteit" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Deze indicatie geeft aan hoeveel keer waarden van deze data element kunnen voorkomen bij een refentielijst van het betreffende type.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Enumeratie -->
+  <xs:element name="Enumeratie" type="mim:Enumeratie">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een datatype waarvan de mogelijke waarden limitatief zijn opgesomd in een statische lijst.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Enumeratie">
+    <xs:complexContent>
+      <xs:extension base="mim:Datatype">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de enumeratie zoals gespecificeerd in de catalogus van de desbetreffende registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de enumeratie zoals gespecificeerd in de catalogus van de desbetreffende registratie.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="enumeratiewaarden">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element ref="mim:Enumeratiewaarde" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="Enumeratiewaarde" type="mim:Enumeratiewaarde">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een gedefinieerde waarde, in de vorm van een eenmalig vastgesteld constant gegeven.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Enumeratiewaarde">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de enumeratiewaarde zoals gespecificeerd in de catalogus van de desbetreffende registratie. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de enumeratiewaarde zoals gespecificeerd in de catalogus van de desbetreffende registratie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="code" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De in een registratie of informatiemodel aan de enumeratiewaarde toegekende unieke code.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Codelijst -->
+  <xs:element name="Codelijst" type="mim:Codelijst">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een lijst met een opsomming van de toegestane/mogelijke domeinwaarden, welke buiten het model in een externe waardenlijst worden beheerd. De domeinwaarden in de lijst kunnen in de loop van de tijd aangepast worden of uitgebreid worden of verwijderd worden, zonder dat het informatiemodel aangepast wordt (in tegenstelling tot bij een enumeratie).</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Codelijst">
+    <xs:complexContent>
+      <xs:extension base="mim:Datatype">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de lijst zoals gespecificeerd in de catalogus van de desbetreffende registratie dan wel, indien het een door de eigen organisatie toegevoegde lijst betreft, de door de eigen organisatie vastgestelde naam.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="alias" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie in wiens catalogus de lijst is gespecificeerd (oftewel de registratie waar de lijst deel van uitmaakt). Deze specificatie is toegevoegd t.o.v. de registratie-catalogus aangezien het hier niet om een registratie gaat maar wel duidelijk moet zijn in welke registratie de (verwijzing naar de) referentielijst voorkomt (indien van toepassing).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de lijst zoals gespecificeerd in de catalogus van de desbetreffende registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="datumOpname" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de lijst is opgenomen in het informatiemodel.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="toelichting" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor lijsten die deel uitmaken van een registratie betreft dit de daarin opgenomen toelichting.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="locatie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verwijzing (URL) naar de locatie van de bijbehorende schema’s met waardenlijsten.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Referentielijst -->
+  <xs:element name="Referentielijst" type="mim:Referentielijst">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De representatie van een lijst met een opsomming van de mogelijke domeinwaarden van een attribuutsoort, die buiten het model in een externe waardenlijst worden beheerd. De domeinwaarden in de lijst kunnen in de loop van de tijd aangepast, uitgebreid, of verwijderd worden, zonder dat het informatiemodel aangepast wordt (in tegenstelling tot bij een enumeratie). De representatie bevat een aantal kenmerken, die overgenomen zijn van de specificatie van de externe waardelijst.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Referentielijst">
+    <xs:complexContent>
+      <xs:extension base="mim:Datatype">
+        <xs:sequence>
+          <xs:element name="naam" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de lijst zoals gespecificeerd in de catalogus van de desbetreffende registratie dan wel, indien het een door de eigen organisatie toegevoegde lijst betreft, de door de eigen organisatie vastgestelde naam van de lijst.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="alias" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="herkomst" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie in wiens catalogus de lijst is gespecificeerd (oftewel de registratie waar de referentielijst deel van uitmaakt). Deze specificatie is toegevoegd t.o.v. de registratie catalogus aangezien het hier niet om een registratie gaat maar wel duidelijk moet zijn in welke registratie de (verwijzing naar de) lijst voorkomt (indien van toepassing). </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="definitie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de lijst zoals gespecificeerd in de catalogus van de desbetreffende registratie. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="datumOpname" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de lijst is opgenomen in het informatiemodel.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="toelichting" type="xs:string" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor lijsten die deel uitmaken van een registratie betreft dit de daarin opgenomen toelichting. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="locatie" type="xs:string">
+            <xs:annotation>
+              <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verwijzing (URL) naar de locatie van de bijbehorende schema’s met waardenlijsten.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="referentieElementen">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element ref="mim:ReferentieElement" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="ReferentieElement" type="mim:ReferentieElement">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een eigenschap van een object in een referentielijst in de vorm van een gegeven. </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="ReferentieElement">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het referentie element is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="type">
+        <xs:complexType>
+          <xs:choice>
+            <xs:element ref="mim-ref:DatatypeRef"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="lengte" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Het exaxt aantal tekens dat de waarde van een referentie element moet bevatten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="patroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De verzameling van waarden die gegevens van deze referentie element kunnen hebben (bereik) dan wel moeten voldoen aan een specifiek patroon.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="formeelPatroon" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Zoals patroon , formeel vastgelegd (met een reguliere expressie)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kardinaliteit" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Deze indicatie geeft aan hoeveel keer waarden van deze referentie element kunnen voorkomen bij een refentielijst van het betreffende type.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="identificerend" type="mim:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat referentie element onderdeel uitmaakt van de unieke aanduiding van een referentielijst.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Relatieklasse -->
+  <xs:element name="Relatieklasse" type="mim:Relatieklasse">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een relatiesoort met eigenschappen.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Relatieklasse">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim:attribuutsoorten" minOccurs="0"/>
+      <xs:element ref="mim:constraints" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Constraint: -->
+  <xs:element name="Constraint" type="mim:Constraint">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een constraint is een conditie of een beperking, die over een of meerdere modelelementen uit het informatiemodel geldt.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="Constraint">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string"/>
+      <xs:element name="specificatieTekst" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De specificatie van de constraint in tekst.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="specificatieFormeel" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De specificatie van de constraint in een formele specifieke taal (OCL).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Generalisatie tussen objecttypes: -->
+  <xs:element name="GeneralisatieObjecttypes" type="mim:GeneralisatieObjecttypes">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van het hiërarchische verband tussen een meer generiek en een meer specifiek modelelement van hetzelfde soort, waarbij het meer specifieke modelelement eigenschappen van het meer generieke modelelement overerft. Dit verband is alleen gedefinieerd voor objecttypen en datatypen.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="GeneralisatieObjecttypes">
+    <xs:sequence>
+      <xs:element name="supertype">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:ObjecttypeRef"/>
+            <xs:element ref="mim-ext:Constructie" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Generalisatie tussen datatypes: -->
+  <xs:element name="GeneralisatieDatatypes" type="mim:GeneralisatieDatatypes">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van het hiërarchische verband tussen een meer generiek en een meer specifiek modelelement van hetzelfde soort, waarbij het meer specifieke modelelement eigenschappen van het meer generieke modelelement overerft. Dit verband is alleen gedefinieerd voor objecttypen en datatypen.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="GeneralisatieDatatypes">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van het referentie element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="supertype">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ref:DatatypeRef"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <!-- Keuze: -->
+  <xs:element name="Keuze" type="mim:Keuze"/>
+  <xs:complexType name="Keuze">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de keuze.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie in wiens catalogus de keuze is gespecificeerd (oftewel de registratie waar het objecttype deel van uitmaakt). Deze specificatie is toegevoegd omdat het wel duidelijk moet zijn in welke (basis)registratie of informatiemodel het objecttype voorkomt (indien van toepassing). </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de keuze.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het referentie element is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice>
+        <xs:element name="attribuutsoorten">
+          <xs:complexType>
+            <xs:sequence minOccurs="2" maxOccurs="unbounded">
+              <xs:element ref="mim:Attribuutsoort"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="datatypen">
+          <xs:complexType>
+            <xs:sequence minOccurs="2" maxOccurs="unbounded">
+              <xs:element ref="mim-ref:DatatypeRef"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="relatiedoelen">
+          <xs:complexType>
+            <xs:sequence minOccurs="2" maxOccurs="unbounded">
+              <xs:element name="Keuze">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="naam" type="xs:string">
+                      <xs:annotation>
+                        <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de keuze.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="doel">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element ref="mim-ref:ObjecttypeRef"/>
+                        </xs:sequence>  
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="aggregatieType" type="mim:typeAggregatie">
+                      <xs:annotation>
+                        <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Standaard betreft het geen aggregatie (None). Het type aggregatie mag ‘composite’ zijn. Dit wordt gedaan als er een afhankelijkheid is dat de target niet kan bestaan zonder de source c.q. de target vervalt als de source vervalt.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="kardinaliteit" type="xs:string"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+
+  <!--
+  <xs:element name="RelatierolKeuze" type="mim:RelatierolKeuze"/>
+  <xs:complexType name="RelatierolKeuze">
+    <xs:complexContent>
+      <xs:extension base="mim:Relatierol"/>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="RelatierolDoelKeuze" type="mim:RelatierolDoelKeuze"/>
+  <xs:complexType name="RelatierolDoelKeuze">
+    <xs:complexContent>
+      <xs:extension base="mim:RelatierolKeuze"/>
+    </xs:complexContent>
+  </xs:complexType>
+  -->
+
+  <xs:element name="ExterneKoppeling" type="mim:ExterneKoppeling">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een associatie waarmee vanuit het perspectief van het eigen informatiemodel een objecttype uit het ‘eigen’ informatiemodel gekoppeld wordt aan een objecttype van een extern informatiemodel. De relatie zelf hoort bij het ‘eigen’ objecttype.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="ExterneKoppeling">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de externe koppeling. Standaard 'betreft'. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de externe koppeling is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="uniDirectioneel" type="xs:string"/>
+      <xs:element name="aggregatieType" type="mim:typeAggregatie">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat het een compositie relatie is.Waarde is altijd Composite.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="doel">
+        <xs:complexType>
+          <xs:choice>
+            <xs:element ref="mim-ref:ObjecttypeRef"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+  <xs:element name="Interface" type="mim:Interface">
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Constructie die een externe instantie beheert en beschikbaar stelt aan een informatiemodel en die in het informatiemodel ongewijzigd gebruikt wordt.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <!-- Interface: -->
+  <xs:complexType name="Interface">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Naam van de interface, zoals GM_Surface (Extern GML) of CharacterString (Extern MIM).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+  </xs:complexType>
+  
+  <xs:element name="attribuutsoorten">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="mim:Attribuutsoort"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="gegevensgroepen">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="mim:Gegevensgroep"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="constraints">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="mim:Constraint" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="boolean">
+    <xs:restriction base="xs:boolean"/>
+    <!--
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Ja"/>
+      <xs:enumeration value="Nee"/>
+    </xs:restriction>
+    -->
+  </xs:simpleType>
+
+  <xs:simpleType name="typeAggregatie">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Geen"/>
+      <xs:enumeration value="Compositie"/>
+      <xs:enumeration value="Gedeeld"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="relatiemodelleringstype">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Relatiesoort leidend"/>
+      <xs:enumeration value="Relatierol leidend"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="MIMVersie">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="1.0"/>
+      <xs:enumeration value="1.1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="MIMTaal">
+    <xs:restriction base="xs:language"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="authentiek">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Authentiek"/>
+      <xs:enumeration value="Basisgegeven"/>
+      <xs:enumeration value="Wettelijk gegeven"/>
+      <xs:enumeration value="Landelijk kerngegeven"/>
+      <xs:enumeration value="Overig"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+</xs:schema>

--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
@@ -55,24 +55,6 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="components" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element ref="mim:Objecttype" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Gegevensgroeptype" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Gegevensgroep" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:GestructureerdDatatype" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:PrimitiefDatatype" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Enumeratie" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Codelijst" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Referentielijst" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Keuze" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:ExterneKoppeling" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim:Interface" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="mim-ext:Constructie" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
       <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required"/>
@@ -84,33 +66,43 @@
     <xs:sequence>
       <xs:element name="datatypen" minOccurs="0">
         <xs:complexType>
-          <xs:sequence>
-            <xs:element ref="mim-ref:DatatypeRef" maxOccurs="unbounded"/>
-          </xs:sequence>
+          <xs:choice maxOccurs="unbounded">
+            <xs:element ref="mim:GestructureerdDatatype"/>
+            <xs:element ref="mim:PrimitiefDatatype"/>
+            <xs:element ref="mim:Enumeratie"/>
+            <xs:element ref="mim:Codelijst"/>
+            <xs:element ref="mim:Referentielijst"/>
+          </xs:choice>
         </xs:complexType>
       </xs:element>
       <xs:element name="objecttypen" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element ref="mim-ref:ObjecttypeRef" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Objecttype" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="gegevensgroeptypen" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element ref="mim-ref:GegevensgroeptypeRef" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Gegevensgroeptype" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="keuzen" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element ref="mim-ref:KeuzeRef" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Keuze" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="mim-ext:constructies" minOccurs="0"/>
+      <xs:element name="constructies" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="mim-ext:Constructie" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="optional"/>
@@ -207,7 +199,7 @@
       <xs:element name="interfaces" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element ref="mim-ref:InterfaceRef" maxOccurs="unbounded"/>
+            <xs:element ref="mim:Interface" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
@@ -295,9 +295,10 @@
       <xs:element ref="mim:gegevensgroepen" minOccurs="0"/>
       <xs:element name="relatiesoorten" minOccurs="0">
         <xs:complexType>
-          <xs:sequence>
-            <xs:element ref="mim:Relatiesoort" maxOccurs="unbounded"/>
-          </xs:sequence>
+          <xs:choice>
+            <xs:element ref="mim:RelatiesoortRelatiesoortLeidend"/>
+            <xs:element ref="mim:RelatiesoortRelatierolLeidend"/>
+          </xs:choice>
         </xs:complexType>
       </xs:element>
       <xs:element name="externeKoppelingen" minOccurs="0">
@@ -414,6 +415,7 @@
         <xs:complexType>
           <xs:choice>
             <xs:element ref="mim-ref:DatatypeRef"/>
+            <xs:element ref="mim-ref:InterfaceRef"/>
             <xs:element ref="mim-ref:KeuzeRef"/>
           </xs:choice>
         </xs:complexType>
@@ -559,136 +561,235 @@
     <xs:attribute name="id" type="xs:ID" use="optional"/>
   </xs:complexType>
 
-  <!-- Relatiesoort: -->
-  <xs:element name="Relatiesoort" type="mim:Relatiesoort">
+  <!-- RelatiesoortRelatiesoortLeidend: -->
+  <xs:element name="RelatiesoortRelatiesoortLeidend" type="mim:RelatiesoortRelatiesoortLeidend">
+    <!-- Relatiesoort leidend (alternatief 1); relatiemodelleringstype == "Relatiesoort leidend" -->
     <xs:annotation>
       <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van het structurele verband tussen een object van een objecttype en een (ander) object van een ander (of hetzelfde) objecttype.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:complexType name="Relatiesoort">
-    <xs:choice>
-      <xs:element name="RelatiesoortLeidend">
-        <!-- Relatiesoort leidend (alternatief 1); relatiemodelleringstype == "Relatiesoort leidend" -->
+  <xs:complexType name="RelatiesoortRelatiesoortLeidend">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="uniDirectioneel" type="xs:string"/>
+      <xs:element name="doel">
         <xs:complexType>
-          <xs:sequence>
-            <xs:element name="naam" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="alias" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="uniDirectioneel" type="xs:string"/>
-            <xs:element name="doel">
-              <xs:complexType>
-                <xs:choice>
-                  <xs:choice>
-                    <xs:element ref="mim-ref:ObjecttypeRef"/>
-                    <xs:element ref="mim-ref:KeuzeRef"/>
-                  </xs:choice>
-                  <xs:element ref="mim:Relatierol"/>
-                </xs:choice>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="aggregatieType" type="mim:typeAggregatie">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Standaard betreft het geen aggregatie (None). Het type aggregatie mag ‘composite’ zijn. Dit wordt gedaan als er een afhankelijkheid is dat de target niet kan bestaan zonder de source c.q. de target vervalt als de source vervalt.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="kardinaliteit" type="xs:string"/>
-            <xs:element name="herkomst" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatiesoort ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="definitie" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="toelichting" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatiesoort.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="herkomstDefinitie" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="datumOpname" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatiesoort is opgenomen in het informatiemodel.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatiesoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="authentiek" type="xs:string">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatiesoort is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="indicatieAfleidbaar" type="mim:boolean"/>
-            <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatiesoort geen waarde met betekenis kan bevatten.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
-            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
-          </xs:sequence>  
+          <xs:choice>
+            <xs:choice>
+              <xs:element ref="mim-ref:ObjecttypeRef"/>
+              <xs:element ref="mim-ref:KeuzeRef"/>
+            </xs:choice>
+          </xs:choice>
         </xs:complexType>
       </xs:element>
-      <xs:element name="RelatierolLeidend">
-        <!-- Relatierol is leidend (alternatief 2); relatiemodelleringstype == "Relatierol leidend" -->    
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="naam" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="alias" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="definitie" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
-            <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
-          </xs:sequence>  
-        </xs:complexType>
+      <xs:element name="aggregatieType" type="mim:typeAggregatie">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Standaard betreft het geen aggregatie (None). Het type aggregatie mag ‘composite’ zijn. Dit wordt gedaan als er een afhankelijkheid is dat de target niet kan bestaan zonder de source c.q. de target vervalt als de source vervalt.</xs:documentation>
+        </xs:annotation>
       </xs:element>
-    </xs:choice>
+      <xs:element name="kardinaliteit" type="xs:string"/>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatiesoort ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatiesoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatiesoort is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatiesoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="authentiek" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatiesoort is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieAfleidbaar" type="mim:boolean"/>
+      <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatiesoort geen waarde met betekenis kan bevatten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="relatierolBron" type="mim:RelatierolRelatiesoortLeidend"/>
+      <xs:element name="relatierolDoel" type="mim:RelatierolRelatiesoortLeidend"/>
+      <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>  
+    <xs:attribute name="id" type="xs:ID" use="optional"/>  
+  </xs:complexType>
+      
+  <!-- RelatiesoortRelatierolLeidend: -->    
+  <xs:element name="RelatiesoortRelatierolLeidend" type="mim:RelatiesoortRelatierolLeidend">
+    <!-- Relatierol is leidend (alternatief 2); relatiemodelleringstype == "Relatierol leidend" -->  
+    <xs:annotation>
+      <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De typering van het structurele verband tussen een object van een objecttype en een (ander) object van een ander (of hetzelfde) objecttype.</xs:documentation>
+    </xs:annotation>
+  </xs:element>    
+  <xs:complexType name="RelatiesoortRelatierolLeidend">
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="relatierolBron" type="mim:RelatierolRelatierolLeidend"/>
+      <xs:element name="relatierolDoel" type="mim:RelatierolRelatierolLeidend"/>
+      <xs:element name="relatieklasse" type="mim:Relatieklasse" minOccurs="0"/>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="optional"/>
   </xs:complexType>
-
+     
   <!-- Relatierol: -->
+  <xs:complexType name="RelatierolRelatiesoortLeidend">
+    <!-- Relatiesoort leidend (alternatief 1); relatiemodelleringstype == "Relatiesoort leidend" -->
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatierol. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatierol. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>  
+  </xs:complexType>
+     
+  <xs:complexType name="RelatierolRelatierolLeidend">
+    <!-- Relatierol is leidend (alternatief 2); relatiemodelleringstype == "Relatierol leidend" --> 
+    <xs:sequence>
+      <xs:element name="naam" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de relatiesoort. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="begrip" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Verwijzing naar een begrip. De verwijzing heeft de vorm van een term of een URI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alias" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De alternatieve weergave van de naam.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomst" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaraan de relatiesoort ontleend is, dan wel de eigen organisatie. Indien zelf toegevoegd, dan is de herkomst de eigen organisatie. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="definitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De beschrijving van de betekenis van de relatiesoort. Deze is verplicht als er geen source role respectievelijk target role is gespecificeerd.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="herkomstDefinitie" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De registratie of het informatiemodel waaruit de definitie is overgenomen dan wel een aanduiding die aangeeft uit welke bronnen de defintie is samengesteld.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datumOpname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop de relatiesoort is opgenomen in het informatiemodel.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="kardinaliteit" type="xs:string"/>
+      <xs:element name="indicatieMaterieleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de materiële historie van de relatiesoort te bevragen is. Materiële historie geeft aan wanneer een verandering is opgetreden in de werkelijkheid die heeft geleid tot verandering van de relatie.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="indicatieFormeleHistorie" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Indicatie of de formele historie van de relatiesoort te bevragen is. Formele historie geeft aan wanneer in de administratie een verandering is verwerkt van de relatie (wanneer was de verandering bekend en is deze verwerkt).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="authentiek" type="xs:string">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding of de attribuutsoort waarvan de relatiesoort is afgeleid, een authentiek gegeven (attribuutsoort) betreft.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mogelijkGeenWaarde" type="mim:boolean">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Aanduiding dat relatiesoort geen waarde met betekenis kan bevatten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toelichting" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Een inhoudelijke toelichting op de relatiesoort.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mim-ext:kenmerken" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <?x
   <xs:element name="Relatierol" type="mim:Relatierol" abstract="true">
     <xs:annotation>
       <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De benaming van de manier waarop een object deelneemt aan een relatie met een ander object.</xs:documentation>
@@ -796,7 +897,9 @@
     </xs:choice>
     <xs:attribute name="id" type="xs:ID" use="optional"/>
   </xs:complexType>
+  ?>
   
+  <?x
   <!-- RelatierolBron: -->
   <xs:element name="RelatierolBron" type="mim:RelatierolBron">
     <xs:annotation>
@@ -881,6 +984,7 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  ?>
 
   <!-- Datatype: -->
   <xs:element name="Datatype" type="mim:Datatype" abstract="true">
@@ -1032,9 +1136,10 @@
       </xs:element>
       <xs:element name="type">
         <xs:complexType>
-          <xs:sequence>
+          <xs:choice>
             <xs:element ref="mim-ref:DatatypeRef"/>
-          </xs:sequence>
+            <xs:element ref="mim-ref:InterfaceRef"/>
+          </xs:choice>
         </xs:complexType>
       </xs:element>
       <xs:element name="lengte" type="xs:string" minOccurs="0">
@@ -1282,6 +1387,7 @@
         <xs:complexType>
           <xs:choice>
             <xs:element ref="mim-ref:DatatypeRef"/>
+            <xs:element ref="mim-ref:InterfaceRef"/>
           </xs:choice>
         </xs:complexType>
       </xs:element>
@@ -1473,36 +1579,20 @@
         </xs:element>
         <xs:element name="datatypen">
           <xs:complexType>
-            <xs:sequence minOccurs="2" maxOccurs="unbounded">
+            <xs:choice minOccurs="2" maxOccurs="unbounded">
               <xs:element ref="mim-ref:DatatypeRef"/>
-            </xs:sequence>
+              <xs:element ref="mim-ref:InterfaceRef"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
         <xs:element name="relatiedoelen">
           <xs:complexType>
             <xs:sequence minOccurs="2" maxOccurs="unbounded">
-              <xs:element name="Keuze">
+              <xs:element name="Relatiedoel">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element name="naam" type="xs:string">
-                      <xs:annotation>
-                        <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De naam van de keuze.</xs:documentation>
-                      </xs:annotation>
-                    </xs:element>
-                    <xs:element name="doel">
-                      <xs:complexType>
-                        <xs:sequence>
-                          <xs:element ref="mim-ref:ObjecttypeRef"/>
-                        </xs:sequence>  
-                      </xs:complexType>
-                    </xs:element>
-                    <xs:element name="aggregatieType" type="mim:typeAggregatie">
-                      <xs:annotation>
-                        <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Standaard betreft het geen aggregatie (None). Het type aggregatie mag ‘composite’ zijn. Dit wordt gedaan als er een afhankelijkheid is dat de target niet kan bestaan zonder de source c.q. de target vervalt als de source vervalt.</xs:documentation>
-                      </xs:annotation>
-                    </xs:element>
-                    <xs:element name="kardinaliteit" type="xs:string"/>
-                  </xs:sequence>
+                    <xs:element ref="mim-ref:ObjecttypeRef"/>
+                  </xs:sequence>  
                 </xs:complexType>
               </xs:element>
             </xs:sequence>

--- a/src/main/resources/etc/xsd/MIMformat/xlink.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/xlink.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xlink="http://www.w3.org/1999/xlink"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xlink"><!--
+This schema is provided by Kadaster as a local copy, as a convenience to the user. This schema may itself reference a local copy of the schema originally referenced by URI. The local reference takes the form of a relative path, and is introduced by Kadaster.
+-->
+   <xs:annotation>
+      <xs:documentation>
+			This is the Xlinks Kadaster profile. It constrains the xlinks schema by 
+			1/ reducing attributes of simple types to @href only, and 
+			2/ allowing only @href to appear on elements.
+			3/ removing reference to xml.xsd
+			Kadaster also uses GML, and GML uses Xlinks; this profile covers the GML case as well.
+		</xs:documentation>
+   </xs:annotation>
+   <!-- bridge added by Geonovum BRO team -->
+   <xs:attributeGroup name="simpleLink">
+      <xs:attributeGroup ref="xlink:simpleAttrs">
+         <xs:annotation>
+            <xs:documentation>see https://www.geonovum.nl/nieuws/belangrijke-informatie-over-wijziging-ogc-standaarden</xs:documentation>
+         </xs:annotation>
+      </xs:attributeGroup>
+   </xs:attributeGroup>
+   <xs:attribute name="href" type="xlink:hrefType"/>
+   <xs:simpleType name="hrefType">
+      <xs:restriction base="xs:anyURI"/>
+   </xs:simpleType>
+   <xs:attributeGroup name="simpleAttrs">
+      <xs:attribute ref="xlink:href"/>
+   </xs:attributeGroup>
+</xs:schema>

--- a/src/main/resources/xsl/MIMCompiler/MIMCompiler.xsl
+++ b/src/main/resources/xsl/MIMCompiler/MIMCompiler.xsl
@@ -182,35 +182,33 @@
           </xsl:where-populated>
           
           <mim:components>
-            <mim:InformatiemodelComponents>
-              <!-- mim:Objectype: -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-objecttype]"/>
-              <!-- mim:Gegevensgroeptype: -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-gegevensgroeptype]"/>
-              <!-- mim:GestructureerdDatatype -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-gestructureerd-datatype]"/>
-              <!-- mim:PrimitiefDatatype -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-primitief-datatype]"/>
-              <!-- mim:Enumeratie -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-enumeratie]"/>
-              <!-- mim:Codelijst -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-codelijst]"/>
-              <!-- mim:Referentielijst -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-referentielijst]"/>
-              <!-- mim:Datatype -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-datatype]"/>
-              <!-- mim:Keuze__Attribuutsoorten -->
-              <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-attributes]"/>
-              <!-- mim:Keuze__Datatypen -->
-              <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-datatypes]"/>
-              <!-- mim:Keuze__Associaties -->
-              <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-associations]"/>
-              <!-- TODO: mim:Extern toevoegen? -->
-              <!-- mim:Interface -->
-              <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-interface and imvert:id]"/>
-              <!-- mim-ext:Constructie -->
-              <xsl:apply-templates select="$classes[imf:is-not-mim-construct(.)]"/>
-            </mim:InformatiemodelComponents>
+            <!-- mim:Objectype: -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-objecttype]"/>
+            <!-- mim:Gegevensgroeptype: -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-gegevensgroeptype]"/>
+            <!-- mim:GestructureerdDatatype -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-gestructureerd-datatype]"/>
+            <!-- mim:PrimitiefDatatype -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-primitief-datatype]"/>
+            <!-- mim:Enumeratie -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-enumeratie]"/>
+            <!-- mim:Codelijst -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-codelijst]"/>
+            <!-- mim:Referentielijst -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-referentielijst]"/>
+            <!-- mim:Datatype -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-datatype]"/>
+            <!-- mim:Keuze__Attribuutsoorten -->
+            <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-attributes]"/>
+            <!-- mim:Keuze__Datatypen -->
+            <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-datatypes]"/>
+            <!-- mim:Keuze__Associaties -->
+            <xsl:apply-templates select="$classes[imvert:stereotype/@id = $stereotype-id-keuze-associations]"/>
+            <!-- TODO: mim:Extern toevoegen? -->
+            <!-- mim:Interface -->
+            <xsl:apply-templates select="$classes[imvert:stereotype = $stereotype-name-interface and imvert:id]"/>
+            <!-- mim-ext:Constructie -->
+            <xsl:apply-templates select="$classes[imf:is-not-mim-construct(.)]"/>
           </mim:components>
           <xsl:call-template name="extensieKenmerken"/>
         </mim:Informatiemodel>    
@@ -1260,7 +1258,7 @@
   
   <xsl:function name="imf:valid-id" as="xs:string?">
     <xsl:param name="id" as="xs:string?"/>
-    <xsl:sequence select="if ($id) then replace(replace(lower-case(normalize-space($id)), '[^a-z_0-9 ]', ''), ' ', '-') else ()"/>
+    <xsl:sequence select="if ($id) then replace(replace(lower-case(normalize-space($id)), '[^a-z0-9 ]', ''), ' ', '-') else ()"/>
   </xsl:function>
   
   <xsl:function name="imf:name" as="xs:string">
@@ -1340,6 +1338,11 @@
         <xsl:for-each select="imvert:tagged-values/imvert:tagged-value[not(@id = $mim-tagged-value-ids)]">
           <mim-ext:kenmerk naam="{imvert:name/@original}">{imvert:value/@original}</mim-ext:kenmerk>
         </xsl:for-each>  
+        <!--
+        <xsl:where-populated>
+          <mim-ext:kenmerk naam="identificerend">{imf:mim-boolean(imvert:is-id)}</mim-ext:kenmerk>
+        </xsl:where-populated>
+        -->
         <xsl:where-populated>
           <mim-ext:kenmerk naam="positie">{imvert:position/@original}</mim-ext:kenmerk>
         </xsl:where-populated>

--- a/src/main/resources/xsl/MIMCompiler/MIMCompiler.xsl
+++ b/src/main/resources/xsl/MIMCompiler/MIMCompiler.xsl
@@ -152,17 +152,17 @@
           <xsl:attribute name="schemaLocation" namespace="http://www.w3.org/2001/XMLSchema-instance">http://www.geostandaarden.nl/mim/informatiemodel/v1 ../xsd/MIMFORMAT/model/v20210609/MIMFORMAT_Mim_v0_0_1.xsd</xsl:attribute>
           
           <mim:naam>{imvert:model-id}</mim:naam>
-          <xsl:call-template name="definitie"/>
-          <xsl:call-template name="herkomst"/>
-          <mim:informatiedomein>{imf:tagged-values(., 'CFG-TV-IMDOMAIN')}</mim:informatiedomein>
-          <mim:informatiemodeltype>{imf:tagged-values(., 'CFG-TV-IMTYPE')}</mim:informatiemodeltype>
-          <mim:relatiemodelleringstype>{imf:tagged-values(., 'CFG-TV-IMRELATIONMODELINGTYPE')}</mim:relatiemodelleringstype>
-          <mim:mIMVersie>{imf:tagged-values(., 'CFG-TV-MIMVERSION')}</mim:mIMVersie>
+          <mim:definitie>{imf:tagged-values-not-traced(., 'CFG-TV-DEFINITION')}</mim:definitie>
+          <mim:herkomst>{imf:tagged-values-not-traced(., 'CFG-TV-SOURCE')}</mim:herkomst>
+          <mim:informatiedomein>{imf:tagged-values-not-traced(., 'CFG-TV-IMDOMAIN')}</mim:informatiedomein>
+          <mim:informatiemodeltype>{imf:tagged-values-not-traced(., 'CFG-TV-IMTYPE')}</mim:informatiemodeltype>
+          <mim:relatiemodelleringstype>{imf:tagged-values-not-traced(., 'CFG-TV-IMRELATIONMODELINGTYPE')}</mim:relatiemodelleringstype>
+          <mim:mIMVersie>{imf:tagged-values-not-traced(., 'CFG-TV-MIMVERSION')}</mim:mIMVersie>
           <xsl:where-populated>
-            <mim:mIMExtensie>{imf:tagged-values(., 'CFG-TV-MIMEXTENSION')}</mim:mIMExtensie>    
+            <mim:mIMExtensie>{imf:tagged-values-not-traced(., 'CFG-TV-MIMEXTENSION')}</mim:mIMExtensie>    
           </xsl:where-populated>
           <xsl:where-populated>
-            <mim:mIMTaal>{imf:tagged-values(., 'CFG-TV-MIMLANGUAGE')}</mim:mIMTaal>  
+            <mim:mIMTaal>{imf:tagged-values-not-traced(., 'CFG-TV-MIMLANGUAGE')}</mim:mIMTaal>  
           </xsl:where-populated>
           <xsl:where-populated>
             <mim:bevat>
@@ -1206,6 +1206,12 @@
   </xsl:function>
   
   <xsl:function name="imf:tagged-values" as="xs:string*" use-when="not($runs-in-imvertor-context)">
+    <xsl:param name="context-node" as="element()"/>
+    <xsl:param name="tag-id" as="xs:string"/>
+    <xsl:sequence select="imf:tagged-values-not-traced($context-node, $tag-id)"/>
+  </xsl:function>
+  
+  <xsl:function name="imf:tagged-values-not-traced" as="xs:string*">
     <xsl:param name="context-node" as="element()"/>
     <xsl:param name="tag-id" as="xs:string"/>
     <xsl:sequence select="for $v in $context-node/imvert:tagged-values/imvert:tagged-value[@id = $tag-id]/imvert:value return normalize-space(string-join($v//text(), ' '))"/>


### PR DESCRIPTION
MIM compiler: 1/ Metagegevens op informatiemodel niveau (MIMVersie, MIMTaal, informatiedomein etc) worden nu correct gegenereerd en 2/ mim:InformatiemodelComponents wrapper verwijderd
MIM schema: Initiele commit MIM XML Schema "fase 2"