### PR TITLE
Toevoeging warnings MIM compiler en kleine wijzigingen MIM serialisatie XML schema

### DIFF
--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimRef_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_MimRef_v1.xsd
@@ -31,7 +31,7 @@
   <xs:element name="KeuzeRef" type="mim-ref:RefType"/>
   <xs:element name="InterfaceRef" type="mim-ref:RefType"/>
   
-  <xs:complexType name="RefType" abstract="true">
+  <xs:complexType name="RefType">
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute ref="xlink:href" use="required"/>

--- a/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
+++ b/src/main/resources/etc/xsd/MIMformat/MIMFORMAT_Mim_v1.xsd
@@ -251,11 +251,13 @@
           <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">De datum waarop het objecttype is opgenomen in het informatiemodel.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <!--
       <xs:element name="uniekeAanduiding" type="xs:string">
         <xs:annotation>
           <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een (basis)registratie of informatiemodel betreft dit de wijze waarop daarin voorkomende objecten (van dit type) uniek in de registratie worden aangeduid. Afgeleid gegeven op basis van combinatie van attribuutsoorten en relatiesoorten met is ID = True</xs:documentation>
         </xs:annotation>
       </xs:element>
+      -->
       <xs:element name="populatie" type="xs:string" minOccurs="0">
         <xs:annotation>
           <xs:documentation source="http://www.imvertor.org/schema-info/technical-documentation">Voor objecttypen die deel uitmaken van een (basis)registratie betreft dit de beschrijving van de exemplaren van het gedefinieerde objecttype die in de desbetreffende (basis)registratie voorhanden zijn.</xs:documentation>
@@ -287,7 +289,7 @@
       <xs:element ref="mim:gegevensgroepen" minOccurs="0"/>
       <xs:element name="relatiesoorten" minOccurs="0">
         <xs:complexType>
-          <xs:choice>
+          <xs:choice maxOccurs="unbounded">
             <xs:element ref="mim:RelatiesoortRelatiesoortLeidend"/>
             <xs:element ref="mim:RelatiesoortRelatierolLeidend"/>
           </xs:choice>


### PR DESCRIPTION
- MIM Compiler: Genereren van attribute 'schemaLocation' tijdelijk uitgeschakeld
- MIM Compiler: Warning toegevoegd: 'Please run the job with &quot;nativescalars = no&quot; when serializing to MIM'
- MIM Compiler: Warning toegevoegd: 'The MIM modelelement for baretype [1] could not be found in the MIM11 package' ipv harde fout
- MIM XML schema: kleine wijzigingen