### PR TITLE
Update conceptual-schemas.xml

### DIFF
--- a/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
+++ b/src/main/resources/input/BRO/xsd/conceptual-schemas.xml
@@ -3,9 +3,11 @@
                       xmlns:cs="http://www.imvertor.org/metamodels/conceptualschemas/model/v20181210"
                       xmlns:cs-ref="http://www.imvertor.org/metamodels/conceptualschemas/model-ref/v20181210"
                       xmlns:xi="http://www.w3.org/2001/XInclude"
-                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <!--
                       xsi:schemaLocation="http://www.imvertor.org/metamodels/conceptualschemas/model/v20181210
-                      ../../../etc/xsd/ConceptualSchema/root/model/v20181210/ConceptualSchemas_Model_v1_0.xsd">
+                      ../../../etc/xsd/ConceptualSchema/root/model/v20181210/ConceptualSchemas_Model_v1_0.xsd"
+                    -->
    <cs:mappings>
       <cs:Mapping>
          <cs:name>BRO_GITHUB</cs:name>
@@ -27,6 +29,7 @@
             <cs-ref:MapRef xlink:href="#INSPIRE-SOIL"/>
             <cs-ref:MapRef xlink:href="#MIM11"/>
             <cs-ref:MapRef xlink:href="#NEN3610"/>
+            <!-- aanpassen? ?x is geen geldig XML token-->
             <?x
             <cs-ref:MapRef xlink:href="#BRO"/>
             <cs-ref:MapRef xlink:href="#BRO-SAMPLE1"/>
@@ -43,12 +46,14 @@
          
          <xi:include href="../../MIM/xsd/cs-MIM11.xml"/><!-- implements ConceptualSchema MIM11 -->
          
+         <!-- mag weg? -->
          <cs:ConceptualSchema>
             <cs:id>Sample1</cs:id>
             <cs:shortName>sample</cs:shortName>
             <cs:desc>Sample conceptual schema, see «Application» Github-14-metamodel links</cs:desc>
             <cs:url>http://www.bro.nl/conceptual-schemas/SampleExternalModelA</cs:url>
          </cs:ConceptualSchema>
+         <!-- hernoemen in GML321? -->
          <cs:ConceptualSchema>
             <cs:id>GML3</cs:id>
             <cs:shortName>gml</cs:shortName>
@@ -126,6 +131,7 @@
          
          <xi:include href="../../MIM/xsd/cm-MIM11.xml"/><!-- implements Map #MIM11 -->
          
+         <!-- mag weg? -->
          <cs:Map>
             <cs:id>SampleExternalModelA</cs:id>
             <cs:namespace>http://www.broservices.nl/SampleExternalModelA</cs:namespace>
@@ -186,14 +192,23 @@
                   </cs:catalogEntries>
                   <cs:xsdTypes>
                      <cs:XsdType>
+                        <!-- aanpassen? -->
+                        <!--
                         <cs:name>Feature</cs:name>
+                        -->
+                        <cs:name>AbstractFeature</cs:name>
+                        <!-- aanpassen? -->
+                        <!--
                         <cs:asAttribute>FeatureType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>FeaturePropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- mag weg? wordt afgedekt door GM_Curve. -->
                <cs:Construct>
                   <cs:name>GM_LineString</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -230,7 +245,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
-		<cs:Construct>
+               <cs:Construct>
                   <cs:name>GM_MultiPoint</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:catalogEntries>
@@ -248,6 +263,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- mag weg? wordt afgedekt door GM_Surface. -->
                <cs:Construct>
                   <cs:name>GM_Polygon</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -266,6 +282,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? -->
                <cs:Construct>
                   <cs:name>GM_Envelope</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -277,31 +294,65 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>Envelope</cs:name>
+                        <!--
                         <cs:asAttribute>EnvelopeType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>BoundingShapeType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? omvat GM_Point, GM_Curve, GM_Surface en GM_Solid, GM_MultiPoint, GM_MultiCurve, GM_MultiSurface en GM_MultiSolid. -->
                <cs:Construct>
+                  <!--
                   <cs:name>GM_AbstractGeometry</cs:name>
+                  -->
+                  <cs:name>GM_Object</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:catalogEntries>
                      <cs:CatalogEntry>
-                        <cs:name>#AbstractGeometry</cs:name>
+                        <cs:name>#Object</cs:name>
                      </cs:CatalogEntry>
                   </cs:catalogEntries>
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>AbstractGeometry</cs:name>
+                        <!--
                         <cs:asAttribute>AbstractGeometryType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>GeometryPropertyType</cs:asAttribute>
+                        <!--
+                        GeometryPropertyType uit geometryBasic0d1d.xsd overnemen in BRO gml-profiel.
+                        -->
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- toevoegen? omvat GM_Point, GM_Curve, GM_Surface en GM_Solid. -->
+               <!-- AbstractGeometricPrimitive, AbstractGeometricPrimitiveType en GeometricPrimitivePropertyType uit geometryBasic0d1d.xsd overnemen in BRO gml-profiel. -->
+               <cs:Construct>
+                  <cs:name>GM_Primitive</cs:name>
+                  <cs:sentinel>false</cs:sentinel>
+                  <cs:catalogEntries>
+                     <cs:CatalogEntry>
+                        <cs:name>#Primitive</cs:name>
+                     </cs:CatalogEntry>
+                  </cs:catalogEntries>
+                  <cs:xsdTypes>
+                     <cs:XsdType>
+                        <cs:name>AbstractGeometricPrimitive</cs:name>
+                        <cs:asAttribute>GeometricPrimitivePropertyType</cs:asAttribute>
+                        <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
+                        <cs:primitive>false</cs:primitive>
+                        <cs:hasNilreason>false</cs:hasNilreason>
+                     </cs:XsdType>
+                  </cs:xsdTypes>
+               </cs:Construct>
+               <!-- verwijderen? omdat GM_Curve het 'interface' vormt. -->
                <cs:Construct>
                   <cs:name>GM_AbstractCurve</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -320,6 +371,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verwijderen? omdat GM_Surface het 'interface' vormt. -->
                <cs:Construct>
                   <cs:name>GM_AbstractSurface</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -338,6 +390,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verwijderen? omdat dit geen interface type is. -->
                <cs:Construct>
                   <cs:name>GM_AbstractRing</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -356,6 +409,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verwijderen? omdat dit geen interface type is. -->
                <cs:Construct>
                   <cs:name>LinearRing</cs:name>
                   <cs:desc>LinearRing is in GML / ISO19136 gedefinieerd. Het heeft geen corresponderende klasse in ISO19107 maar is in GML toegevoegd als convenience type, een simpelere vorm van GM_Ring en formeel een subklasse daarvan.</cs:desc>
@@ -375,18 +429,19 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verwijderen? duplicaat met regel 311 -->
                <cs:Construct>
                   <cs:name>GM_Object</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:catalogEntries>
                      <cs:CatalogEntry>
-                        <cs:name>#GM_Object</cs:name>
+                        <cs:name>#Object</cs:name>
                      </cs:CatalogEntry>
                   </cs:catalogEntries>
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>AbstractGeometry</cs:name>
-                        <cs:asAttribute>AbstractGeometryType</cs:asAttribute>
+                        <cs:asAttribute>GeometryPropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
@@ -411,6 +466,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? -->
                <cs:Construct>
                   <cs:name>GM_MultiSurface</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -422,13 +478,17 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>MultiSurface</cs:name>
+                        <!--
                         <cs:asAttribute>MultiSurfaceType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>MultiSurfacePropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verwijderen? want geen onderdeel van simple features profile -->
                <cs:Construct>
                   <cs:name>GM_MultiSolid</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -440,13 +500,17 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>MultiSolid</cs:name>
+                        <!--
                         <cs:asAttribute>MultiSolidType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>MultiSolidPropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? -->
                <cs:Construct>
                   <cs:name>GM_Curve</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -458,13 +522,17 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>Curve</cs:name>
+                        <!--
                         <cs:asAttribute>CurveType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>CurvePropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- MultiCurve, MultiCurveType en MultiCurvePropertyType uit geometryAggregates.xsd overnemen in BRO gml-profiel. -->
                <cs:Construct>
                   <cs:name>GM_MultiCurve</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -477,12 +545,14 @@
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
+                  <!-- wat is het doel van het rdfType? Moet die niet bij veel meer constructs worden ingevuld? -->
                   <cs:rdfTypes>
                      <cs:RdfType>
                         <cs:name>rdfs:Datatype</cs:name>
                      </cs:RdfType>
                   </cs:rdfTypes>
                </cs:Construct>
+               <!-- verwijderen? want geen onderdeel van simple features profile -->
                <cs:Construct>
                   <cs:name>GM_Solid</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -501,6 +571,7 @@
                      </cs:RdfType>
                   </cs:rdfTypes>
                </cs:Construct>
+               <!-- aanpassen? -->
                <cs:Construct>
                   <cs:name>TM_Instant</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -512,13 +583,17 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>TimeInstant</cs:name>
+                        <!--
                         <cs:asAttribute>TimeInstantType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>TimeInstantPropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? -->
                <cs:Construct>
                   <cs:name>TM_Period</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -530,35 +605,44 @@
                   <cs:xsdTypes>
                      <cs:XsdType>
                         <cs:name>TimePeriod</cs:name>
+                        <!--
                         <cs:asAttribute>TimePeriodType</cs:asAttribute>
+                        -->
+                        <cs:asAttribute>TimePeriodPropertyType</cs:asAttribute>
                         <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
                         <cs:primitive>false</cs:primitive>
                         <cs:hasNilreason>false</cs:hasNilreason>
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verplaatsen naar nieuwe map Coverages? -->
                <cs:Construct>
                   <!--herkomst: ISO19123:2005 Coverages -->
                   <cs:name>CV_Coverage</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                </cs:Construct>
+               <!-- verplaatsen naar nieuwe map Coverages? -->
 			   <cs:Construct>                  
                   <cs:name>CV_GridCell</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                </cs:Construct>
+               <!-- verplaatsen naar nieuwe map Coverages? -->
 			   <cs:Construct>                  
                   <cs:name>CV_RangeSet</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                </cs:Construct>
+               <!-- verplaatsen naar nieuwe map Coverages? -->
 			   <cs:Construct>                  
                   <cs:name>CV_DomainSet</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                </cs:Construct>
+               <!-- verplaatsen naar nieuwe map Coverages? -->
               <cs:Construct>
                   <!--herkomst: ISO19123:2018 Coverages -->
                   <cs:name>Coverage</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                </cs:Construct>	
+               <!-- verplaatsen naar map INSPIRE? -->
 			   <cs:Construct>
                   <cs:name>Identifier</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -577,6 +661,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verplaatsen naar map INSPIRE-SOIL? -->
                <cs:Construct>
                   <cs:name>OtherSoilNameType</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -595,6 +680,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- verplaatsen naar map INSPIRE-SOIL? -->
                <cs:Construct>
                   <cs:name>WRBSoilNameType</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -856,7 +942,9 @@
                </cs:Construct>
             </cs:constructs>
          </cs:Map>
+         <!-- aanpassen? ?x is geen geldig XML token-->
          <?x
+         <!-- mag weg? -->
          <cs:Map>
             <cs:id>BRO</cs:id>
             <cs:namespace>http://determine/</cs:namespace>
@@ -889,6 +977,7 @@
                </cs:Construct>
             </cs:constructs>
          </cs:Map>
+         <!-- mag weg? -->
          <cs:Map>
             <cs:id>BRO-SAMPLE1</cs:id>
             <cs:namespace>http://determine/</cs:namespace>
@@ -951,6 +1040,7 @@
                </cs:Construct>
             </cs:constructs>
          </cs:Map>
+         <!-- mag weg? -->
          <cs:Map>
             <cs:id>BRO-SAMPLE2</cs:id>
             <cs:namespace>http://determine/</cs:namespace>
@@ -1056,7 +1146,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
-	       <cs:Construct>
+              <cs:Construct>
                   <cs:name>ChamberOfCommerceNumber</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:xsdTypes>
@@ -1215,7 +1305,7 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
-	       <cs:Construct>
+	           <cs:Construct>
                   <cs:name>IndicatieJaNeeOnbekend</cs:name>
                   <cs:sentinel>false</cs:sentinel>
                   <cs:xsdTypes>
@@ -1252,7 +1342,6 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
-
                <cs:Construct>
                   <cs:name>Coördinatenpaar</cs:name>
                   <cs:sentinel>false</cs:sentinel>
@@ -1265,7 +1354,9 @@
                      </cs:XsdType>
                   </cs:xsdTypes>
                </cs:Construct>
+               <!-- aanpassen? ?x is geen geldig XML token-->
                <?x
+               <!-- mag weg? -->
                <cs:Construct>
                   <cs:name>CoRdinatenpaar</cs:name>
                   <cs:sentinel>false</cs:sentinel>


### PR DESCRIPTION
juiste asAttribute types, zodat er minder aanpassingen hoeven worden gemaakt in de door Imvertor gegenereerde XSD, zoals:
EnvelopeType                -> BoundingShapeType
GM_Curve                      -> CurvePropertyType
MultiSurfaceType           -> MultiSurfacePropertyType
AbstractGeometryType  -> GeometryPropertyType
non-GML constructs verplaatsen naar Coverages cq INSPIRE cq INSPIRE-SOIL
GML-constructs beperken tot 'interface' UML classes.