### PR TITLE
BRO: Locatie van waardenlijsten kan nu ook als pad worden opgegeven.

### DIFF
--- a/src/main/resources/xsl/OfficeCompiler/Imvert2modeldoc-lists.xsl
+++ b/src/main/resources/xsl/OfficeCompiler/Imvert2modeldoc-lists.xsl
@@ -112,7 +112,8 @@
                     <xsl:sequence select="imf:msg(.,'FATAL','Owner parameter doclist-xml-url not defined',())"/>
                 </xsl:when>
                 <xsl:when test="normalize-space($loc)">
-                    <xsl:variable name="url" select="imf:merge-parms($doclist-xml-url)"/>
+                    <!-- Wanneer het een URL met xmlk extensie betreft, dan integraal overnemen. Anders oplossen op basis van de doclist-xml-url. -->
+                    <xsl:variable name="url" select="if (matches($loc,'^https?://.*?\.xml$','i')) then $loc else imf:merge-parms($doclist-xml-url)"/>
                     <xsl:sequence select="imf:msg(.,'DEBUG','Reading [1] entries from: [2]',(imf:get-config-stereotypes(imvert:stereotype/@id),$url))"/>
                     <xsl:variable name="xml" select="if (unparsed-text-available($url)) then document($url) else ()"/>
                     <xsl:choose>


### PR DESCRIPTION
Dit is de implememntatie van #296

Minor. De regel breekt niet in op bestaande locatie-waarden.