### PR TITLE
Tagged value: Relatienaam inverse

### DIFF
--- a/src/main/resources/input/Kadaster/cfg/tvsets/KadasterMIM111.xml
+++ b/src/main/resources/input/Kadaster/cfg/tvsets/KadasterMIM111.xml
@@ -202,6 +202,15 @@
                 <stereo minmax="0..1">stereotype-name-data-element</stereo>
             </stereotypes>
         </tv>
+
+        <tv norm="space" id="CFG-TV-RELATIONNAMEINVERSE">
+            <name lang="nl">Relatienaam inverse</name>
+            <name lang="en">Relation name inverse</name>
+            <derive>yes</derive>
+            <stereotypes>
+                <stereo minmax="0..1">stereotype-name-relatiesoort</stereo>
+            </stereotypes>
+        </tv>
     </tagged-values>
 
 </tagset>


### PR DESCRIPTION
Deze tagged value ontbreekt nog in de MIM XML export. Is dit voldoende om deze toe te voegen?
Of kan dit PR beter richting de FB-336 branch?