### PR TITLE
Added GM_MultiPrimitive

### DIFF
--- a/src/main/resources/input/BRO/xsd/cm-GML321-profile.xml
+++ b/src/main/resources/input/BRO/xsd/cm-GML321-profile.xml
@@ -388,6 +388,23 @@
              </cs:RdfType>
           </cs:rdfTypes>
        </cs:Construct>
+       <cs:Construct>
+          <cs:name>GM_MultiPrimitive</cs:name>
+          <cs:sentinel>false</cs:sentinel>
+          <cs:xsdTypes>
+             <cs:XsdType>
+                <cs:name>MultiPrimitive</cs:name>
+                <cs:asAttribute>MultiGeometryPropertyType</cs:asAttribute>
+                <cs:asAttributeDesignation>complextype</cs:asAttributeDesignation>
+                <cs:primitive>false</cs:primitive>
+             </cs:XsdType>
+          </cs:xsdTypes>
+          <cs:rdfTypes>
+             <cs:RdfType>
+                <cs:name>rdfs:Datatype</cs:name>
+             </cs:RdfType>
+          </cs:rdfTypes>
+       </cs:Construct>
        <!-- verwijderen? want geen onderdeel van simple features profile -->
        <cs:Construct>
           <cs:name>GM_Solid</cs:name>


### PR DESCRIPTION
Added Construct for GM_MultiPrimitive to BRO/xsd/cm-GML321-profile.xml

Copied from OGC/xsd/cm-GML322.xml.

I will update the XSD for the BRO GML profile after testing this construct for GM_MultiPrimitive with conceptual and logical models.