### PR TITLE
Inkomende relaties niet meer tekenen (zie #544).

### DIFF
--- a/src/main/resources/input/Geonovum/cfg/docrules/Geonovum-MIMEXT1.xml
+++ b/src/main/resources/input/Geonovum/cfg/docrules/Geonovum-MIMEXT1.xml
@@ -61,4 +61,11 @@
         <name lang="en">Multiplicity</name>
     </doc-rule>
     
+    <!--
+        Include incoming associations in the short overview?
+        Wilko Quak: Deze regel heb ik in overleg met Paul Jannsen toegevoegd met de volgende redenering: Inkomende
+         relaties zijn geen eigenschap van het objecttype dus hebben geen betekenis, er gebeurt niets mee.
+    -->
+    <include-incoming-associations>no</include-incoming-associations>
+    
 </doc-rules>


### PR DESCRIPTION
Deze pull request moet ervoor zorgen dat voor Geonovum modelling inkomende relaties niet meer getoond worden in de catalogus naar aanleiding van suggestie in #544.