### PR TITLE
Vervang verwijzingen naar VNG Realisatie

### DIFF
--- a/src/main/resources/input/Justid/cfg/owners/Justid.xml
+++ b/src/main/resources/input/Justid/cfg/owners/Justid.xml
@@ -124,9 +124,9 @@
     <parameter name="message-collapse-keys">TV1NSBRF2 NAFFA NAFF1 TCBR1</parameter>
 
     <!-- URL of the standard JSON components are available -->
-    <parameter name="standard-components-url">https://raw.githubusercontent.com/VNG-Realisatie/API-Kennisbank/master/common/</parameter>
-    <parameter name="standaard-organisatie-components-url">https://raw.githubusercontent.com/VNG-Realisatie/API-Kennisbank/master/common/</parameter>
-    <parameter name="geonovum-components-url">https://raw.githubusercontent.com/VNG-Realisatie/API-Kennisbank/master/common/</parameter>
+    <parameter name="standard-components-url">https://raw.githubusercontent.com/Ewout124/Justid/main/API-Kennisbank/common/</parameter>
+    <parameter name="standaard-organisatie-components-url">https://raw.githubusercontent.com/Ewout124/Justid/main/API-Kennisbank/common/</parameter>
+    <parameter name="geonovum-components-url">https://raw.githubusercontent.com/Ewout124/Justid/main/API-Kennisbank/common/</parameter>
 
     <parameter name="standard-components-file">common.yaml</parameter>
     <parameter name="standard-organisatie-components-file">Generieke-Datatypen-Gemeenten.yaml</parameter>


### PR DESCRIPTION
Verwijzingen naar VNG Realisatie vervangen door verwijzingen naar Ewout124. (Tot nader order gebruiken we repositories die zijn gekoppeld aan het persoonlijke GitHub-account van Ewout. Niet ideaal, maar het moet maar even zo.) 

Ik heb over deze aanpassing afstemming gehad met Robert Melskens.